### PR TITLE
enable server side rendering

### DIFF
--- a/src/addons/SoundPlayerContainer.js
+++ b/src/addons/SoundPlayerContainer.js
@@ -15,7 +15,11 @@ class SoundPlayerContainer extends Component {
                 https://github.com/soundblogs/react-soundplayer#usage`
             );
         }
-        this.soundCloudAudio = new SoundCloudAudio(props.clientId);
+        // Dont create a SoundCloudAudio instance
+        // if there is no `window`
+        if ('undefined' !== typeof window) {
+            this.soundCloudAudio = new SoundCloudAudio(props.clientId);
+        }
 
         this.state = {
             duration: 0,


### PR DESCRIPTION
The SoundCloudAudio class assumes to always run in the browser.

If we only create an instance, if there actually is a `window`, server side rendering works like a charm.

I'm not sure, if there is a better way to accomplish this. What do you think?

I would really like to use your module within my app.