### PR TITLE
Adds inline styles through props.

### DIFF
--- a/src/components/Cover.js
+++ b/src/components/Cover.js
@@ -6,11 +6,11 @@ let { PropTypes, Component } = React;
 
 class Cover extends Component {
     render() {
-        let { backgroundUrl, trackName, artistName, className, children } = this.props;
+        let { backgroundUrl, trackName, artistName, className, styles, children } = this.props;
         let classNames = ClassNames('sb-soundplayer-cover', className);
 
         return (
-            <div style={{backgroundImage: `url(${backgroundUrl})`}} className={classNames}>
+            <div style={{backgroundImage: `url(${backgroundUrl})`}} className={classNames} style={styles}>
                 <div>
                     <SoundCloudLogoSVG />
                 </div>
@@ -28,6 +28,7 @@ class Cover extends Component {
 
 Cover.propTypes = {
     className: PropTypes.string,
+    styles: PropTypes.object,
     backgroundUrl: PropTypes.string.isRequired,
     trackName: PropTypes.string.isRequired,
     artistName: PropTypes.string.isRequired

--- a/src/components/Cover.js
+++ b/src/components/Cover.js
@@ -6,11 +6,11 @@ let { PropTypes, Component } = React;
 
 class Cover extends Component {
     render() {
-        let { backgroundUrl, trackName, artistName, className, styles, children } = this.props;
+        let { backgroundUrl, trackName, artistName, className, style, children } = this.props;
         let classNames = ClassNames('sb-soundplayer-cover', className);
 
         return (
-            <div style={{backgroundImage: `url(${backgroundUrl})`}} className={classNames} style={styles}>
+            <div className={classNames} style={Object.assign(style, {backgroundImage: `url(${backgroundUrl})`})}>
                 <div>
                     <SoundCloudLogoSVG />
                 </div>
@@ -28,7 +28,6 @@ class Cover extends Component {
 
 Cover.propTypes = {
     className: PropTypes.string,
-    styles: PropTypes.object,
     backgroundUrl: PropTypes.string.isRequired,
     trackName: PropTypes.string.isRequired,
     artistName: PropTypes.string.isRequired

--- a/src/components/NextButton.js
+++ b/src/components/NextButton.js
@@ -18,12 +18,11 @@ class NextButton extends Component {
     }
 
     render() {
-        let { className } = this.props;
-
+        let { className, styles } = this.props;
         let classNames = ClassNames('sb-soundplayer-play-btn', className);
 
         return (
-            <button type="button" className={classNames} onClick={this.handleClick.bind(this)}>
+            <button type="button" className={classNames} style={styles} onClick={this.handleClick.bind(this)}>
                 <NextIconSVG />
             </button>
         );
@@ -32,6 +31,7 @@ class NextButton extends Component {
 
 NextButton.propTypes = {
     className: PropTypes.string,
+    styles: React.PropTypes.object,
     onNextClick: PropTypes.func,
     soundCloudAudio: PropTypes.instanceOf(SoundCloudAudio)
 };

--- a/src/components/NextButton.js
+++ b/src/components/NextButton.js
@@ -18,11 +18,11 @@ class NextButton extends Component {
     }
 
     render() {
-        let { className, styles } = this.props;
+        let { className, style } = this.props;
         let classNames = ClassNames('sb-soundplayer-play-btn', className);
 
         return (
-            <button type="button" className={classNames} style={styles} onClick={this.handleClick.bind(this)}>
+            <button type="button" className={classNames} style={style} onClick={this.handleClick.bind(this)}>
                 <NextIconSVG />
             </button>
         );
@@ -31,7 +31,6 @@ class NextButton extends Component {
 
 NextButton.propTypes = {
     className: PropTypes.string,
-    styles: React.PropTypes.object,
     onNextClick: PropTypes.func,
     soundCloudAudio: PropTypes.instanceOf(SoundCloudAudio)
 };

--- a/src/components/PlayButton.js
+++ b/src/components/PlayButton.js
@@ -26,7 +26,7 @@ class PlayButton extends Component {
     }
 
     render() {
-        let { playing, seekingIcon, seeking, className } = this.props;
+        let { playing, seekingIcon, seeking, className, styles } = this.props;
 
         let iconNode;
         if (seeking && seekingIcon) {
@@ -40,7 +40,7 @@ class PlayButton extends Component {
         let classNames = ClassNames('sb-soundplayer-play-btn', className);
 
         return (
-            <button type="button" className={classNames} onClick={this.handleClick.bind(this)}>
+            <button type="button" className={classNames} style={styles} onClick={this.handleClick.bind(this)}>
                 {iconNode}
             </button>
         );
@@ -49,6 +49,7 @@ class PlayButton extends Component {
 
 PlayButton.propTypes = {
     className: PropTypes.string,
+    styles: PropTypes.object,
     seeking: PropTypes.bool,
     playing: PropTypes.bool,
     onTogglePlay: PropTypes.func,

--- a/src/components/PlayButton.js
+++ b/src/components/PlayButton.js
@@ -26,7 +26,7 @@ class PlayButton extends Component {
     }
 
     render() {
-        let { playing, seekingIcon, seeking, className, styles } = this.props;
+        let { playing, seekingIcon, seeking, className, style } = this.props;
 
         let iconNode;
         if (seeking && seekingIcon) {
@@ -40,7 +40,7 @@ class PlayButton extends Component {
         let classNames = ClassNames('sb-soundplayer-play-btn', className);
 
         return (
-            <button type="button" className={classNames} style={styles} onClick={this.handleClick.bind(this)}>
+            <button type="button" className={classNames} style={style} onClick={this.handleClick.bind(this)}>
                 {iconNode}
             </button>
         );
@@ -49,7 +49,6 @@ class PlayButton extends Component {
 
 PlayButton.propTypes = {
     className: PropTypes.string,
-    styles: PropTypes.object,
     seeking: PropTypes.bool,
     playing: PropTypes.bool,
     onTogglePlay: PropTypes.func,

--- a/src/components/PrevButton.js
+++ b/src/components/PrevButton.js
@@ -18,12 +18,12 @@ class PrevButton extends Component {
     }
 
     render() {
-        let { className } = this.props;
+        let { className, styles } = this.props;
 
         let classNames = ClassNames('sb-soundplayer-play-btn', className);
 
         return (
-            <button type="button" className={classNames} onClick={this.handleClick.bind(this)}>
+            <button type="button" className={classNames} style={styles} onClick={this.handleClick.bind(this)}>
                 <PrevIconSVG />
             </button>
         );
@@ -32,6 +32,7 @@ class PrevButton extends Component {
 
 PrevButton.propTypes = {
     className: PropTypes.string,
+    styles: PropTypes.object,
     onPrevClick: PropTypes.func,
     soundCloudAudio: PropTypes.instanceOf(SoundCloudAudio)
 };

--- a/src/components/PrevButton.js
+++ b/src/components/PrevButton.js
@@ -18,12 +18,12 @@ class PrevButton extends Component {
     }
 
     render() {
-        let { className, styles } = this.props;
+        let { className, style } = this.props;
 
         let classNames = ClassNames('sb-soundplayer-play-btn', className);
 
         return (
-            <button type="button" className={classNames} style={styles} onClick={this.handleClick.bind(this)}>
+            <button type="button" className={classNames} style={style} onClick={this.handleClick.bind(this)}>
                 <PrevIconSVG />
             </button>
         );
@@ -32,7 +32,6 @@ class PrevButton extends Component {
 
 PrevButton.propTypes = {
     className: PropTypes.string,
-    styles: PropTypes.object,
     onPrevClick: PropTypes.func,
     soundCloudAudio: PropTypes.instanceOf(SoundCloudAudio)
 };

--- a/src/components/Progress.js
+++ b/src/components/Progress.js
@@ -18,7 +18,7 @@ class Progress extends Component {
     }
 
     render() {
-        let { value, className, innerClassName } = this.props;
+        let { value, className, styles, innerClassName, innerStyles } = this.props;
 
         if (value < 0) {
             value = 0;
@@ -28,13 +28,14 @@ class Progress extends Component {
             value = 100;
         }
 
-        let style = {width: `${value}%`};
         let classNames = ClassNames('sb-soundplayer-progress-container', className);
         let innerClassNames = ClassNames('sb-soundplayer-progress-inner', innerClassName);
+        let innerStyle = {width: `${value}%`};
+        innerStyles = Object.assign(innerStyle, innerStyles);
 
         return (
-            <div className={classNames} onClick={this.handleSeekTrack.bind(this)}>
-                <div className={innerClassNames} style={style} />
+            <div className={classNames} style={styles} onClick={this.handleSeekTrack.bind(this)}>
+                <div className={innerClassNames} style={innerStyles} />
             </div>
         );
     }
@@ -42,7 +43,9 @@ class Progress extends Component {
 
 Progress.propTypes = {
     className: PropTypes.string,
+    styles: PropTypes.object,
     innerClassName: React.PropTypes.string,
+    innerStyles: PropTypes.object,
     value: React.PropTypes.number,
     onSeekTrack: PropTypes.func,
     soundCloudAudio: PropTypes.instanceOf(SoundCloudAudio)

--- a/src/components/Progress.js
+++ b/src/components/Progress.js
@@ -18,7 +18,7 @@ class Progress extends Component {
     }
 
     render() {
-        let { value, className, styles, innerClassName, innerStyles } = this.props;
+        let { value, className, innerClassName, style, innerStyle } = this.props;
 
         if (value < 0) {
             value = 0;
@@ -30,12 +30,11 @@ class Progress extends Component {
 
         let classNames = ClassNames('sb-soundplayer-progress-container', className);
         let innerClassNames = ClassNames('sb-soundplayer-progress-inner', innerClassName);
-        let innerStyle = {width: `${value}%`};
-        innerStyles = Object.assign(innerStyle, innerStyles);
+        innerStyle = Object.assign(innerStyle, {width: `${value}%`});
 
         return (
-            <div className={classNames} style={styles} onClick={this.handleSeekTrack.bind(this)}>
-                <div className={innerClassNames} style={innerStyles} />
+            <div className={classNames} style={style} onClick={this.handleSeekTrack.bind(this)}>
+                <div className={innerClassNames} style={innerStyle} />
             </div>
         );
     }
@@ -43,9 +42,8 @@ class Progress extends Component {
 
 Progress.propTypes = {
     className: PropTypes.string,
-    styles: PropTypes.object,
     innerClassName: React.PropTypes.string,
-    innerStyles: PropTypes.object,
+    innerStyle: PropTypes.object,
     value: React.PropTypes.number,
     onSeekTrack: PropTypes.func,
     soundCloudAudio: PropTypes.instanceOf(SoundCloudAudio)

--- a/src/components/Timer.js
+++ b/src/components/Timer.js
@@ -24,11 +24,11 @@ class Timer extends Component {
     }
 
     render() {
-        let { duration, currentTime, className } = this.props;
+        let { duration, currentTime, className, styles } = this.props;
         let classNames = ClassNames('sb-soundplayer-timer', className);
 
         return (
-            <div className={classNames}>
+            <div className={classNames} style={styles}>
                 {Timer.prettyTime(currentTime)} / {Timer.prettyTime(duration)}
             </div>
         );
@@ -37,6 +37,7 @@ class Timer extends Component {
 
 Timer.propTypes = {
     className: PropTypes.string,
+    styles: PropTypes.object,
     duration: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.number

--- a/src/components/Timer.js
+++ b/src/components/Timer.js
@@ -24,11 +24,11 @@ class Timer extends Component {
     }
 
     render() {
-        let { duration, currentTime, className, styles } = this.props;
+        let { duration, currentTime, className, style } = this.props;
         let classNames = ClassNames('sb-soundplayer-timer', className);
 
         return (
-            <div className={classNames} style={styles}>
+            <div className={classNames} style={style}>
                 {Timer.prettyTime(currentTime)} / {Timer.prettyTime(duration)}
             </div>
         );
@@ -37,7 +37,6 @@ class Timer extends Component {
 
 Timer.propTypes = {
     className: PropTypes.string,
-    styles: PropTypes.object,
     duration: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.number


### PR DESCRIPTION
Not sure you want to merge this, but just sharing as an idea. Finding it useful for adding styles through props for Radium, BassCSS-Radium, (React) CSS Modules, React JSS, etc. Doing stuff like

```
import Bass from 'basscss-radium';
...
          <div style={Object.assign(Bass.flex, Bass.flexCenter)}>
            <Progress
              value={currentTime / duration * 100 || 0}
              styles={Object.assign(Bass.mt1, Bass.mb1, Bass.rounded)}
              innerStyles={Bass.roundedLeft}
              {...this.props}
            />
          </div>
```

from the player.