### PR TITLE
Fixes inline styles throwing an error when not passed

### DIFF
--- a/src/components/Progress.js
+++ b/src/components/Progress.js
@@ -30,7 +30,10 @@ class Progress extends Component {
 
         let classNames = ClassNames('sb-soundplayer-progress-container', className);
         let innerClassNames = ClassNames('sb-soundplayer-progress-inner', innerClassName);
-        innerStyle = Object.assign(innerStyle, {width: `${value}%`});
+        
+        if (innerStyle) {
+            innerStyle = Object.assign(innerStyle, {width: `${value}%`});
+        }
 
         return (
             <div className={classNames} style={style} onClick={this.handleSeekTrack.bind(this)}>


### PR DESCRIPTION
This fixes the `<Progress />` component from throwing a `Uncaught TypeError: Cannot convert undefined or null to object` when a styles object is NOT passed in through the `innerStyle` prop.