### PR TITLE
Playlist index issue fix

### DIFF
--- a/src/components/PlayButton.js
+++ b/src/components/PlayButton.js
@@ -17,7 +17,7 @@ class PlayButton extends Component {
         let { playing, soundCloudAudio, onTogglePlay } = this.props;
 
         if (!playing) {
-            soundCloudAudio && soundCloudAudio.play();
+            soundCloudAudio && soundCloudAudio.play({ playlistIndex: soundCloudAudio._playlistIndex });
         } else {
             soundCloudAudio && soundCloudAudio.pause();
         }


### PR DESCRIPTION
Not sure if this fix is necessary here but I was having issues with playlists, specifically keeping the playlist index right within a playlist. The issue was playing the first song in a playlist and moving to the next track, pausing that track and then playing it again messes the `_playlistIndex` up and resets back to 0. 

I think this is more of an issue with `soundCloudAudio`; I dove into `soundCloudAudio` and I think this line within the play method is causing the issue:
 `this._playlistIndex = options.playlistIndex || 0;`

Because the `PlayButton` doesn't pass in a `options.playlistIndex`, it resets the `_playlistIndex` back to 0.