### PR TITLE
Fixes JS builds, and examples.

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -26,12 +26,12 @@ import BackgroundSoundPlayer from './players/BackgroundSoundPlayer';
 
 // dummy data
 const stepanIMeduza = 'https://soundcloud.com/stepan-i-meduza-official/dolgo-obyasnyat';
-const shura = 'https://soundcloud.com/shura/shura-indecision-12-edit-1';
+const pedro = 'https://soundcloud.com/oscar-b-lewis/pedro-fm-theme';
 const glassCandy = 'https://soundcloud.com/johnnyjewel/glass-candy-shell-game';
 const sayLouLou = 'https://soundcloud.com/sayloulou/nothing-but-a-heartbeat';
 const pcMusic = 'https://soundcloud.com/pcmus/sets/deep-trouble';
 const data = {
-    image: 'https://d1v2xm8p2pd3wl.cloudfront.net/tracks/1a87a43ec633f01a917d23fc5e026bf9/640x400.jpg',
+    image: 'https://i1.sndcdn.com/artworks-000113169457-9bvvb7-t500x500.jpg',
     artist: 'franiefroufrou',
     track: 'Exploding Whale by Sufjan Stevens'
 };
@@ -363,7 +363,7 @@ class BuiltInPlayers extends React.Component {
                 </div>
                 <BasicSoundPlayer
                     clientId={clientId}
-                    resolveUrl={shura}
+                    resolveUrl={pedro}
                     {...this.props}
                 />
                 <ProgressSoundPlayer

--- a/examples/package.json
+++ b/examples/package.json
@@ -19,7 +19,10 @@
       ]
     ]
   },
-  "dependencies": {},
+  "dependencies": {
+    "react": "^0.14.8",
+    "react-dom": "^0.14.8"
+  },
   "devDependencies": {
     "uglify-js": "^2.4.20"
   }

--- a/examples/players/BasicSoundPlayer.js
+++ b/examples/players/BasicSoundPlayer.js
@@ -9,7 +9,7 @@ class Player extends Component {
             <div className="p1 mb3 mt3 flex flex-center bg-darken-1 red rounded">
                 <PlayButton className="flex-none h4 mr2 button button-transparent button-grow rounded" {...this.props} />
                 <h2 className="h5 nowrap caps flex-auto m0">{track ? track.title : 'Loading...'}</h2>
-                <Timer className="h6 mr1" duration={track ? track.duration / 1000 : 0} currentTime={currentTime} />
+                <Timer className="h6 mr1" duration={track ? track.duration / 1000 : 0} currentTime={currentTime} {...this.props} />
             </div>
         );
     }

--- a/examples/players/PlaylistSoundPlayer.js
+++ b/examples/players/PlaylistSoundPlayer.js
@@ -76,7 +76,7 @@ class Player extends Component {
                 <div className="p2">
                     <div className="flex flex-center">
                         <h2 className="h4 flex-auto nowrap m0 semibold">{playlist ? playlist.user.username : ''}</h2>
-                        <Timer className="h6 mr1 regular" duration={duration || 0} currentTime={currentTime} />
+                        <Timer className="h6 mr1 regular" duration={duration || 0} currentTime={currentTime} {...this.props} />
                     </div>
                     <h2 className="h2 nowrap caps mt0 mb2 semibold">{playlist ? playlist.title : ''}</h2>
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "example": "examples"
   },
   "repository": {
-   "type": "git",
-   "url": "git://github.com/soundblogs/react-soundplayer.git"
+    "type": "git",
+    "url": "git://github.com/soundblogs/react-soundplayer.git"
   },
   "scripts": {
     "build-js": "rm -rf ./lib && babel src -d lib --stage 0",
@@ -29,11 +29,8 @@
   "dependencies": {
     "classnames": "^2.1.2",
     "object-assign": "^4.0.1",
-    "soundcloud-audio": "^1.0.3"
-  },
-  "peerDependencies": {
-    "react": "^0.14.x",
-    "react-dom": "^0.14.x"
+    "soundcloud-audio": "^1.0.3",
+    "react": "^0.14.x"
   },
   "devDependencies": {
     "babel": "^5.1.2",
@@ -43,6 +40,6 @@
     "cssnext": "^1.2.3",
     "envify": "^3.4.0",
     "highlight.js": "^8.5.0",
-    "watchify": "^2.4.0"
+    "watchify": "^3.7.0"
   }
 }

--- a/src/components/Cover.js
+++ b/src/components/Cover.js
@@ -30,5 +30,8 @@ Cover.propTypes = {
     trackName: PropTypes.string.isRequired,
     artistName: PropTypes.string.isRequired
 };
+Cover.defaultProps = {
+    style: {}
+};
 
 export default Cover;

--- a/src/components/NextButton.js
+++ b/src/components/NextButton.js
@@ -8,7 +8,7 @@ class NextButton extends Component {
         return false;
     }
 
-    handleClick() {
+    handleClick(e) {
         let { soundCloudAudio, onNextClick } = this.props;
 
         soundCloudAudio && soundCloudAudio.next();


### PR DESCRIPTION
- Fixes 404's and 403's in examples/app.js (apparently shura's tracks are no longer streamable)
- Moves `react` to a dependency of both projects (fixes #36)
- Removes peer dependency `react-dom` from main project
- Gives Timer.js the `{...this.props}` it needs in example players (partially fixes #38)
- Give props.style a default value of `{}` in `Cover.js` (fixes @ruffrey's issue in #24)
- Updates `watchify` to latest to fix `npm start` in examples dev environment
- Fixes NextButton's `handleclick()` function to pass event `e`