### PR TITLE
onReady for resolveURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,44 @@ _(String)_ - this could be regular link from SoundCloud web app which points to 
 "https://soundcloud.com/stepan-i-meduza-official/sets/dolgo-obyasnyat-ep"
 ```
 
+##### `onReady`
+
+_(function)_ - if using `resolveUrl`, pass a function to be called when the track or playlist is resolved and ready to be played. Will not be called if you use `streamUrl`. The function is called without any arguments:
+
+```javascript
+import React from 'react';
+import { SoundPlayerContainer } from 'react-soundplayer/addons';
+
+const clientId = 'YOUR CLIENT ID';
+const resolveUrl = 'https://soundcloud.com/thrilljockey/future-islands-balance';
+
+class AppPlayer extends React.Component {
+    constructor(){
+        super();
+        this.trackReady = this.trackReady.bind(this);
+    }
+
+    trackReady(){
+        console.log('Track can be played!')
+        // Enable the play button, or start playing programmatically, etc
+    }
+
+    render() {
+        <div>
+            <SoundPlayerContainer
+                clientId={clientId}
+                resolveUrl={resolveUrl}
+                onReady={this.trackReady}
+            >
+                {/* your custom player components */}
+            </SoundPlayerContainer>
+        </div>
+    }
+}
+
+React.render(<AppPlayer />, document.body);
+```
+
 ##### `streamUrl`
 
 _(String)_ - pass here pure stream url as it's returned by [SoundCloud API](https://developers.soundcloud.com/docs/api/reference#tracks), it has higher priority than `resolveUrl`, example:

--- a/src/addons/SoundPlayerContainer.js
+++ b/src/addons/SoundPlayerContainer.js
@@ -34,7 +34,8 @@ SoundPlayerContainer.propTypes = {
     onStartTrack: PropTypes.func,
     onStopTrack: PropTypes.func,
     onPauseTrack: PropTypes.func,
-    onVolumeChange: PropTypes.func
+    onVolumeChange: PropTypes.func,
+    onReady: PropTypes.func
 };
 
 export default withSoundCloudAudio(SoundPlayerContainer);

--- a/src/addons/withSoundCloudAudio.js
+++ b/src/addons/withSoundCloudAudio.js
@@ -31,6 +31,7 @@ export default function withSoundCloudAudio (WrappedComponent) {
             }
 
             this.state = {
+                ready: !!props.streamUrl,
                 duration: 0,
                 currentTime: 0,
                 seeking: false,
@@ -53,7 +54,7 @@ export default function withSoundCloudAudio (WrappedComponent) {
 
         requestAudio() {
             const { soundCloudAudio } = this;
-            const { resolveUrl, streamUrl } = this.props;
+            const { resolveUrl, streamUrl, onReady } = this.props;
 
             if (streamUrl) {
                 soundCloudAudio.preload(streamUrl);
@@ -64,7 +65,7 @@ export default function withSoundCloudAudio (WrappedComponent) {
                     }
                     this.setState({
                         [data.tracks ? 'playlist' : 'track']: data
-                    });
+                    }, () => onReady && onReady());
                 });
             }
         }

--- a/src/addons/withSoundCloudAudio.js
+++ b/src/addons/withSoundCloudAudio.js
@@ -31,7 +31,6 @@ export default function withSoundCloudAudio (WrappedComponent) {
             }
 
             this.state = {
-                ready: !!props.streamUrl,
                 duration: 0,
                 currentTime: 0,
                 seeking: false,


### PR DESCRIPTION
I needed to know when a track was ready to be played so that I could programmatically start playing it, so I added this `onReady` prop.

Happy to write docs / examples, but wanted to run the approach by the maintainers first.

thanks for this component, super handy!