### PR TITLE
Fix bug on Playlist example : wrong selected track

### DIFF
--- a/examples/players/PlaylistSoundPlayer.js
+++ b/examples/players/PlaylistSoundPlayer.js
@@ -48,7 +48,7 @@ class Player extends Component {
 
         let tracks = playlist.tracks.map((track, i) => {
             let classNames = ClassNames('flex flex-center full-width left-align button button-transparent', {
-                'is-active': this.state.activeIndex === i
+                'is-active': this.props.soundCloudAudio._playlistIndex === i 
             });
 
             return (


### PR DESCRIPTION
When you don't click "Play" button to read the track but choose to click on "Next" button, the Player reads the first track of the playlist, but the Player show it's playing the second.

This patch fixes this issue.

Regards