### PR TITLE
Allow updating url & custom start time in  withSoundCloudAudio.js

### DIFF
--- a/src/addons/withSoundCloudAudio.js
+++ b/src/addons/withSoundCloudAudio.js
@@ -54,8 +54,18 @@ export default function withSoundCloudAudio (WrappedComponent) {
     }
 
     componentDidUpdate(prevProps) {
-      if (this.props.streamUrl === prevProps.streamUrl) return;
+      this.props.streamUrl !== prevProps.streamUrl &&
+        this.init(prevProps);
+    }
 
+    componentWillUnmount() {
+      this.mounted = false;
+
+      resetPlayedStore();
+      this.soundCloudAudio.unbindAll();
+    }
+
+    init(prevProps) {
       if (this.props.streamUrl) {
         this.setState({ hasSetStartTime: false }, () => {
           this.requestAudio();
@@ -77,13 +87,6 @@ export default function withSoundCloudAudio (WrappedComponent) {
           hasSetStartTime: false
         });
       }
-    }
-
-    componentWillUnmount() {
-      this.mounted = false;
-
-      resetPlayedStore();
-      this.soundCloudAudio.unbindAll();
     }
 
     requestAudio() {


### PR DESCRIPTION
This resolves the following feature requests:

1. Change a song by updating the streamUrl prop #98 #86 #101
2. Pass a start time to begin playing the audio from (as a number in seconds) #99 

I also checked and #87 doesn't seem to be open any more, I can seek tracks on custom urls.


## Usage

```js
const MediaPlayer = withCustomAudio(ChildAudioPlayerComponent)

const MainWindow = React.memo(props => (
  <div>
    <h2>Player</h2>
    <MediaPlayer
      {...props}
      streamUrl={props.track.url}
      startTime={props.track.startTime} // Number (seconds)
      clientId="xxx" // to silence log warning on custom urls
    />
  </div>
))
```

## Preview

Here's a preview of the custom start at time, and changing the streamUrl without un-mounting or ref hack. If the player is playing when the track changes, it will keep playing.

(the gif adds a little choppiness)

![playerchanges (1)](https://user-images.githubusercontent.com/8600215/63656307-64438080-c74f-11e9-9770-5a9341f236a6.gif)
